### PR TITLE
Update openSUSE description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Some distributions ship an [extremely outdated](https://github.com/svenstaro/rof
 #### Package Manager
 
 * [Arch AUR](https://aur.archlinux.org/packages/rofi-calc/)
-* [OpenSUSE Leap](https://software.opensuse.org/package/rofi-calc)
+* [openSUSE](https://software.opensuse.org/package/rofi-calc)
 
 #### From source
 


### PR DESCRIPTION
We have rofi-calc in an official devel repo (X11:Utilities/rofi-calc)
now. It builds there for openSUSE Leap and Tumbleweed. So the
description needs to be adapted.

Additionally it will in official repos for openSUSE Tumbleweed from the
next snapshot on.

Regards https://github.com/svenstaro/rofi-calc/issues/19