### PR TITLE
WIP: Adds an optional user-provided shell command (-calc-command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Run rofi like:
 
     rofi -show calc -modi calc -no-show-match -no-sort
 
+The result of the current input can be selected with `Ctrl+Enter`, and history entries can be selected with `Enter`. By default this will just output the equation/result.
+
+Use the `-calc-command` option to specify a shell command to execute which will be interpolated with the following keys:
+
+* `{expression}`: the left-side of the equation
+* `{result}`: the right of the equation
+
+The following example copies the result to the clipboard (NOTE: `{result}` should be quoted since it may contain characters that your shell would otherwise interpret):
+
+    rofi -show calc -modi calc -no-show-match -no-sort -calc-command "echo '{result}' | xclip"
+
 It's convenient to bind it to a key combination in i3. For instance, you could use:
 
     bindsym $mod+c exec --no-startup-id "rofi -show calc -modi calc -no-show-match -no-sort"

--- a/src/calc.c
+++ b/src/calc.c
@@ -160,8 +160,7 @@ static ModeMode calc_mode_result(Mode* sw, int menu_entry, G_GNUC_UNUSED char** 
         retv = PREVIOUS_DIALOG;
     } else if (menu_entry & MENU_QUICK_SWITCH) {
         retv = (menu_entry & MENU_LOWER_MASK);
-    } else if (((menu_entry & MENU_OK) && selected_line == 0) ||
-               ((menu_entry & MENU_CUSTOM_INPUT) && selected_line == -1u)) {
+    } else if ((menu_entry & MENU_OK) && selected_line == 0) {
         if (!is_error_string(pd->last_result) && strlen(pd->last_result) > 0) {
             char* history_entry = g_strdup_printf("%s", pd->last_result);
             g_ptr_array_add(pd->history, (gpointer) history_entry);
@@ -171,6 +170,13 @@ static ModeMode calc_mode_result(Mode* sw, int menu_entry, G_GNUC_UNUSED char** 
         char* entry = g_ptr_array_index(pd->history, get_real_history_index(pd->history, selected_line));
         execsh(pd->cmd, entry);
         retv = MODE_EXIT;
+    } else if (menu_entry & MENU_CUSTOM_INPUT) {
+        if (!is_error_string(pd->last_result) && strlen(pd->last_result) > 0) {
+            execsh(pd->cmd, pd->last_result);
+            retv = MODE_EXIT;
+        } else {
+            retv = RELOAD_DIALOG;
+        }
     } else if (menu_entry & MENU_ENTRY_DELETE) {
         if (selected_line > 0) {
             g_ptr_array_remove_index(pd->history, get_real_history_index(pd->history, selected_line));

--- a/src/calc.c
+++ b/src/calc.c
@@ -136,11 +136,16 @@ static void execsh(char* cmd, char* entry)
 
     // Otherwise, we will execute -calc-command
     gchar **parts = g_strsplit (entry, EQUATION_TOKEN_DELIM, 2);
-    char *complete_cmd = helper_string_replace_if_exists(cmd,
+    char *user_cmd = helper_string_replace_if_exists(cmd,
             EQUATION_LHS_KEY, parts[0],
             EQUATION_RHS_KEY, parts[1],
             NULL);
     g_free(parts);
+
+    // Escape it to pass to /bin/sh
+    gchar *escaped_cmd = g_strescape(user_cmd, NULL);
+    gchar *complete_cmd = g_strdup_printf("/bin/sh -c \"%s\"", escaped_cmd);
+    g_free(escaped_cmd);
 
     helper_execute_command(NULL, complete_cmd, FALSE, NULL);
 }


### PR DESCRIPTION
This adds a `-calc-command` option whose contents will be interpolated with `{expression}` and `{result}` and then passed to `/bin/sh -c`. If no command is specified, the entire qalc result will be sent to `printf()` as is the current behaviour. 

This can be used to copy results to the clipboard, for example with `-calc-command "echo {result} | xclip"` addressing #3. 