### PR TITLE
Fix parsing result with -terse

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use the `-terse` option to reduce the output of `qalc` to just the result of the
 
 Use the `-calc-command` option to specify a shell command to execute which will be interpolated with the following keys:
 
-* `{expression}`: the left-side of the equation
+* `{expression}`: the left-side of the equation (currently not available when using `-terse`)
 * `{result}`: the right of the equation
 
 The following example copies the result to the clipboard (NOTE: `{result}` should be quoted since it may contain characters that your shell would otherwise interpret):

--- a/src/calc.c
+++ b/src/calc.c
@@ -149,6 +149,14 @@ static int get_real_history_index(GPtrArray* history, unsigned int selected_line
 // character.
 static char** split_equation(char* string)
 {
+    char** result = malloc(2 * sizeof(char*));
+
+    if (find_arg(TERSE_OPTION) > -1) {
+        result[0] = NULL;
+        result[1] = g_strdup(string); // with -terse, string _is_ the result
+        return result;
+    }
+
     int parens_depth = 0;
     char* curr = string;
 
@@ -170,7 +178,6 @@ static char** split_equation(char* string)
 
     // Strip trailing whitespace with `g_strchomp()` from the left.
     // Strip leading whitespace with `g_strchug()` from the right.
-    char** result = malloc(2 * sizeof(char*));
     result[0] = g_strchomp(string);
     result[1] = g_strchug(curr + 1);
 


### PR DESCRIPTION
Hacky but quick way to fix parsing `{result}` when using `-terse` flag. 

I guess a more superior approach would be to also save `input` in some kind of `pd->last_input` variable when executing `qalc`, maybe even join both in history (so that with `-terse` the history still contains input _and_ result, although I'm not sure if it's a good idea), and maybe if we have `pd->last_input` and `pd->last_result` it would be possible to simplify parsing in `execsh()`... but it feels like a lot of work, and since I only need `{result}`, I thought a pragmatic approach might be to wait until somebody actually needs more than this 😄 