### PR TITLE
[README.md] Fix i3 bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ NOTE: `{result}` should be quoted since it may contain characters that your shel
 
 It's convenient to bind it to a key combination in i3. For instance, you could use:
 
-    bindsym $mod+c exec --no-startup-id "rofi -show calc -modi calc -no-show-match -no-sort"
+    bindsym $mod+c exec --no-startup-id "rofi -show calc -modi calc -no-show-match -no-sort > /dev/null"
 
 To disable the bold font applied to the results by default, you can use the flag `-no-bold` and run rofi like:
 


### PR DESCRIPTION
Without this fix, rofi-calc will spam into the console from which i3 was opened.
For example: I am running xserver with i3 from tty1 for tty7. Do some calculations(in tty7) with rofi-calc and move on to tty1. See spam from rofi-calc like:
```
1 + 1 = 2
2 * 2 = 4
```