### PR TITLE
Correctly handle multiple equals signs emitted by qalc

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -333,17 +333,18 @@ static char** split_equation(char* string)
     }
 
     int parens_depth = 0;
-    char* curr = string;
+    char* curr = string + strlen(string);
     int delimiter_len = 0;
 
     // Iterate through and track our level of nestedness, stopping when
     // we've hit an equals sign not inside other parentheses.
     // At this point we can set the NULL character to split the string
     // into `string` and `curr + delimiter_len`.
-    while (*curr) {
-        if (*curr == PARENS_LEFT) {
+    while (curr != string) {
+        curr--;
+        if (*curr == PARENS_RIGHT) {
             parens_depth++;
-        } else if (*curr == PARENS_RIGHT) {
+        } else if (*curr == PARENS_LEFT) {
             parens_depth--;
         } else if (parens_depth == 0) {
             if (*curr == EQUALS_SIGN) {
@@ -354,14 +355,22 @@ static char** split_equation(char* string)
                 break;
             }
         }
-        curr++;
     }
-    *curr = '\0';
 
-    // Strip trailing whitespace with `g_strchomp()` from the left.
-    // Strip leading whitespace with `g_strchug()` from the right.
-    result[0] = g_strchomp(string);
-    result[1] = g_strchug(curr + delimiter_len);
+    if (curr == string) {
+        // No equals signs were found. Shouldn't happen, but if it does treat
+        // the entire expression as the result.
+        result[0] = NULL;
+        result[1] = g_strdup(string);
+    } else {
+        // We found an equals sign; set it to null to split the string in two.
+        *curr = '\0';
+
+        // Strip trailing whitespace with `g_strchomp()` from the left.
+        // Strip leading whitespace with `g_strchug()` from the right.
+        result[0] = g_strchomp(string);
+        result[1] = g_strchug(curr + delimiter_len);
+    }
 
     return result;
 }


### PR DESCRIPTION
Given some inputs like `1 + 1/2` qalc will emit a result with several `=` signs:

```
1 + (1 / 2) = 3/2 = 1 + 1/2 = 1.5
```

Previously, rofi-calc considered the result of this calculation to be `3/2 = 1 + 1/2 = 1.5` which is not right. By searching for the equals sign from the right instead of the left, we will always correctly identify the result - in this case, `1.5`.