### PR TITLE
skip escaping some unicode math symbols

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -407,7 +407,7 @@ static void execsh(char* cmd, char* entry)
             NULL);
     g_free(parts);
 
-    gchar *escaped_cmd = g_strescape(user_cmd, NULL);
+    gchar *escaped_cmd = g_strescape(user_cmd, "·−×√²³⊻↊↋¬°");
     gchar *complete_cmd = g_strdup_printf("/bin/sh -c \"%s\"", escaped_cmd);
     g_free(user_cmd);
     g_free(escaped_cmd);

--- a/src/calc.c
+++ b/src/calc.c
@@ -407,7 +407,9 @@ static void execsh(char* cmd, char* entry)
             NULL);
     g_free(parts);
 
-    gchar *escaped_cmd = g_strescape(user_cmd, "·−×√²³⊻↊↋¬°");
+    // don't escape these utf-8 runes which appear in qalc output, the escape sequences are not recognized by shell (#108)
+    static const char *unescaped_chars = "·−×√²³⊻↊↋¬°";
+    gchar *escaped_cmd = g_strescape(user_cmd, unescaped_chars);
     gchar *complete_cmd = g_strdup_printf("/bin/sh -c \"%s\"", escaped_cmd);
     g_free(user_cmd);
     g_free(escaped_cmd);


### PR DESCRIPTION
add some math symbols to skip glib escape for `-calc-command`

Fixes #108 

If needed, I could put the extra escapes behind an argument like `-calc-command-skip-escapes`. Not sure of all the `-calc-command` use-cases and how this could affect them.