### PR TITLE
Error Message Color (basic implementation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ mainbox {
 ```
 Reference Rofi docs: [Layout](https://github.com/davatorium/rofi/blob/next/doc/rofi-theme.5.markdown#layout), [Base Widgets](https://github.com/davatorium/rofi/blob/next/doc/rofi-theme.5.markdown#base-widgets), [Children](https://github.com/davatorium/rofi/blob/next/doc/rofi-theme.5.markdown#children)
 
+### Changing the color of the error message
+The error message is rendered in the same `textbox` as the result. By default, it uses the color `PaleVioletRed`, which can be changed by supplying the `-calc-error-color '$COLOR'` option, where `$COLOR` can be in one of the following formats:
+
+- `#{HEX}{3}` (rgb)
+- `#{HEX}{4}` (rgba)
+- `#{HEX}{6}` (rrggbb)
+- `#{HEX}{8}` (rrggbbaa)
+- `{named-color}`
+
+Reference Rofi docs: [Color](https://github.com/davatorium/rofi/blob/next/doc/rofi-theme.5.markdown#color)
+
+**NOTE:** Other color formats mentioned there (like `rgb[a]()`, `hsl[a]()`, etc.) can not be used and will throw a `Pango-WARNING`.
 
 ## Development
 

--- a/src/calc.c
+++ b/src/calc.c
@@ -44,6 +44,7 @@ typedef struct
     char* cmd;
     char *hint_result;
     char *hint_welcome;
+    char *calc_error_color;
     char *last_result;
     char *previous_input;
     GPtrArray* history;

--- a/src/calc.c
+++ b/src/calc.c
@@ -84,7 +84,7 @@ typedef struct
 #define HINT_WELCOME_STR "Calculator"
 
 // Option to specify error color
-#define CALC_ERROR_COLOR "-error-color"
+#define CALC_ERROR_COLOR "-calc-error-color"
 #define CALC_ERROR_COLOR_STR "PaleVioletRed"
 
 // The following keys can be specified in `CALC_COMMAND_FLAG` and

--- a/src/calc.c
+++ b/src/calc.c
@@ -82,6 +82,10 @@ typedef struct
 #define HINT_WELCOME "-hint-welcome"
 #define HINT_WELCOME_STR "Calculator"
 
+// Option to specify error color
+#define CALC_ERROR_COLOR "-error-color"
+#define CALC_ERROR_COLOR_STR "PaleVioletRed"
+
 // The following keys can be specified in `CALC_COMMAND_FLAG` and
 // will be replaced with the left-hand side and right-hand side of
 // the equation.
@@ -244,6 +248,13 @@ static void get_calc(Mode* sw)
     char *cmd = NULL;
     if (find_arg_str(CALC_COMMAND_OPTION, &cmd)) {
         pd->cmd = g_strdup(cmd);
+    }
+
+    char *calc_error_color = NULL;
+    if (find_arg_str(CALC_ERROR_COLOR, &calc_error_color)) {
+        pd->calc_error_color = g_strdup(calc_error_color);
+    } else {
+        pd->calc_error_color = CALC_ERROR_COLOR_STR;
     }
 
     pd->hint_result = find_arg_str(HINT_RESULT, &cmd)
@@ -612,7 +623,7 @@ static char *calc_get_message ( const Mode *sw )
 {
     CALCModePrivateData* pd = (CALCModePrivateData*)mode_get_private_data(sw);
     if (is_error_string(pd->last_result)) {
-        return g_markup_printf_escaped("<span foreground='PaleVioletRed'>%s</span>", pd->last_result);
+        return g_markup_printf_escaped("<span foreground='%s'>%s</span>", calc_error_color, pd->last_result);
     }
 
     if (*pd->last_result) {

--- a/src/calc.c
+++ b/src/calc.c
@@ -624,7 +624,7 @@ static char *calc_get_message ( const Mode *sw )
 {
     CALCModePrivateData* pd = (CALCModePrivateData*)mode_get_private_data(sw);
     if (is_error_string(pd->last_result)) {
-        return g_markup_printf_escaped("<span foreground='%s'>%s</span>", calc_error_color, pd->last_result);
+        return g_markup_printf_escaped("<span foreground='%s'>%s</span>", pd->calc_error_color, pd->last_result);
     }
 
     if (*pd->last_result) {


### PR DESCRIPTION
Added a way to customize the color of calculator error messages, as described in #85.
Also added a bit of documentation for the new option.