### PR TITLE
Fix multiline outputs only showing the first line

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -324,6 +324,14 @@ static int get_real_history_index(GPtrArray* history, unsigned int selected_line
 static void append_last_result_to_history(CALCModePrivateData* pd) {
     if (!is_error_string(pd->last_result) && strlen(pd->last_result) > 0) {
         char* history_entry = g_strdup_printf("%s", pd->last_result);
+
+        // Replace newlines with semicolons so one entry isn't split into multiple entries
+        for (unsigned int i = 0; i < strlen(history_entry); i++) {
+            if (history_entry[i] == '\n') {
+                history_entry[i] = ';';
+            }
+        }
+
         g_ptr_array_add(pd->history, (gpointer) history_entry);
         if (find_arg(NO_PERSIST_HISTORY_OPTION) == -1) {
             append_str_to_history(history_entry);

--- a/src/calc.c
+++ b/src/calc.c
@@ -539,9 +539,10 @@ static void process_cb(GObject* source_object, GAsyncResult* res, gpointer user_
         error = NULL;
     }
 
+    gsize bytes_read = 0;
     unsigned int stdout_bufsize = 4096;
     char stdout_buf[stdout_bufsize];
-    g_input_stream_read_all(stdout_stream, stdout_buf, stdout_bufsize, NULL, NULL, &error);
+    g_input_stream_read_all(stdout_stream, stdout_buf, stdout_bufsize, &bytes_read, NULL, &error);
 
     if (error != NULL) {
         g_error("Process errored with: %s", error->message);
@@ -549,8 +550,7 @@ static void process_cb(GObject* source_object, GAsyncResult* res, gpointer user_
         error = NULL;
     }
 
-    unsigned int line_length = strcspn(stdout_buf, "\n");
-    *last_result = g_strndup(stdout_buf, line_length);
+    *last_result = g_strndup(stdout_buf, bytes_read - 1);
     g_input_stream_close(stdout_stream, NULL, &error);
 
     if (error != NULL) {


### PR DESCRIPTION
Fixes #124 and #88. Instead of just truncating on the first line, display all bytes read (minus the newline) from stdout as the result. Here's the output with this fix:
![rofi-calc-fix](https://github.com/user-attachments/assets/4d204f35-8384-4d0a-adfe-f0cd2e41579e)

The only issue I found is that the history will save a separate entry for each newline (in the picture above, the history would have `x=1` first and `((3 x x) + 2) = 5` below it). This may be desired to allow users to be able to select just the variable solution or just the equation. However, if this isn't desired, then I can add another patch to replace all newlines in each history entry with a semicolon, so the entry would instead be `((3 x x) + 2) = 5;x=1`.