### PR TITLE
fix: not compiling on rofi < 1.7.6

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -660,5 +660,9 @@ Mode mode =
     ._preprocess_input  = calc_preprocess_input,
     .private_data       = NULL,
     .free               = NULL,
+    #ifdef MODE_TYPE_SWITCHER
+    #error "lol"
+    // Only recent rofi versions have this so we'll have to use this ifdef
     .type               = MODE_TYPE_SWITCHER,
+    #endif
 };

--- a/src/calc.c
+++ b/src/calc.c
@@ -660,9 +660,8 @@ Mode mode =
     ._preprocess_input  = calc_preprocess_input,
     .private_data       = NULL,
     .free               = NULL,
-    #ifdef MODE_TYPE_SWITCHER
-    #error "lol"
+#if ABI_VERSION >= 7u
     // Only recent rofi versions have this so we'll have to use this ifdef
     .type               = MODE_TYPE_SWITCHER,
-    #endif
+#endif
 };


### PR DESCRIPTION
fixes errors when compiling on ubuntu which uses rofi 1.7.5.
uses `ABI_VERSION` to check rofi version