### PR TITLE
fix: potential crash when private data is NULL

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -638,11 +638,11 @@ static ModeMode calc_mode_result(Mode *sw, int menu_entry,
 
 static void calc_mode_destroy(Mode *sw) {
     CALCModePrivateData *pd = (CALCModePrivateData *)mode_get_private_data(sw);
-    if (pd->config.automatic_save_to_history) {
-        append_last_result_to_history(pd);
-    }
 
     if (pd != NULL) {
+        if (pd->config.automatic_save_to_history) {
+            append_last_result_to_history(pd);
+        }
         g_free(pd);
         mode_set_private_data(sw, NULL);
     }


### PR DESCRIPTION
When playing with rofi I found a weird thing that rofi exits with segmentation fault without any arguments provided:
<img width="480" height="52" alt="image" src="https://github.com/user-attachments/assets/aaa9ea76-b3c5-4df3-8540-85c3d048c78c" />

That made me curious about why it's crashing, so I put it into `gdb` and find out it's in `rofi-calc`'s code. So here is a quick fix for that.