### PR TITLE
fix: respect calc-command-history option from config file

### DIFF
--- a/src/calc.c
+++ b/src/calc.c
@@ -620,7 +620,7 @@ static ModeMode calc_mode_result(Mode *sw, int menu_entry,
     } else if (menu_entry & MENU_CUSTOM_INPUT) {
         if (!is_error_string(pd->last_result) && strlen(pd->last_result) > 0) {
             if (!pd->config.no_history &&
-                find_arg("-" CALC_COMMAND_USES_HISTORY) != -1) {
+                pd->config.calc_command_uses_history) {
                 char *history_entry = g_strdup_printf("%s", pd->last_result);
                 g_ptr_array_add(pd->history, (gpointer)history_entry);
                 if (!pd->config.no_persist_history) {


### PR DESCRIPTION
After my last PR, I noticed that `calc-command-history` wasn't working as a config file option; it only worked when passed on the command line.

Since `set_config` already calls `find_arg` and `rofi_theme_find_property` to populate `pd->config.calc_command_uses_history`, this patch changes `calc_mode_result` to check that instead.

This ensures the config file setting is respected and avoids a redundant call to `find_arg`.
