### PR TITLE
Add live result list entry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ meson compile -C build/
 
     This will have no effect if `-no-history` is enabled.
 
+- Use `-live-result-entry` to display the current calculation result as the
+  only list entry:
+
+        rofi -show calc -modi calc -live-result-entry
+
+    The entry is updated while typing. Calculation history is disabled in this
+    mode, and pressing `Return` on the result prints it to stdout or executes
+    the configured `-calc-command`.
+
+    Since the result is exposed as a regular list entry instead of only through
+    rofi's message widget, this option can also be used with combi mode:
+
+        rofi -show combi -combi-modes "drun,run,calc" -live-result-entry
+
+    Use `-terse` to show only the calculated value instead of the full equation:
+
+        rofi -show combi -combi-modes "drun,run,calc" -live-result-entry -terse
+
+    The option can also be enabled in the rofi config:
+
+        calc {
+            live-result-entry: true;
+            terse: true;
+        }
+
 - To enable thousand separators in the output (e.g. `5 * 12 = 6,000`, rather than `6000`) add the following to `~/.config/qalculate/qalc.cfg`
 
     - For `,` separator:

--- a/src/calc.c
+++ b/src/calc.c
@@ -49,6 +49,7 @@ typedef struct {
     gboolean automatic_save_to_history;
     gboolean calc_command_uses_history;
     gboolean reuse_result;
+    gboolean live_result_entry;
 } CALCModeConfig;
 
 // The internal data structure holding the private data of the TEST Mode.
@@ -89,6 +90,9 @@ typedef struct {
 
 // Option to reuse result as input on add-to-history
 #define REUSE_RESULT_OPTION "reuse-result"
+
+// Option to show the live result as the only entry
+#define LIVE_RESULT_ENTRY_OPTION "live-result-entry"
 
 // Option to specify result hint
 #define HINT_RESULT_OPTION "hint-result"
@@ -271,6 +275,7 @@ static void set_config(Mode *sw) {
     pd->config.automatic_save_to_history = FALSE;
     pd->config.calc_command_uses_history = FALSE;
     pd->config.reuse_result = FALSE;
+    pd->config.live_result_entry = FALSE;
 
     pd->hint_result = HINT_RESULT_STR;
     pd->hint_welcome = HINT_WELCOME_STR;
@@ -360,6 +365,13 @@ static void set_config(Mode *sw) {
         if (reuse_result != NULL && (reuse_result->type == P_BOOLEAN)) {
             pd->config.reuse_result = reuse_result->value.b;
         }
+
+        Property *live_result_entry = rofi_theme_find_property(
+            config_file, P_BOOLEAN, LIVE_RESULT_ENTRY_OPTION, TRUE);
+        if (live_result_entry != NULL &&
+            (live_result_entry->type == P_BOOLEAN)) {
+            pd->config.live_result_entry = live_result_entry->value.b;
+        }
     }
 
     // command line options
@@ -387,6 +399,9 @@ static void set_config(Mode *sw) {
     if (find_arg("-" REUSE_RESULT_OPTION) > -1)
         pd->config.reuse_result = TRUE;
 
+    if (find_arg("-" LIVE_RESULT_ENTRY_OPTION) > -1)
+        pd->config.live_result_entry = TRUE;
+
     char *cmd = NULL;
     if (find_arg_str("-" CALC_COMMAND_OPTION, &cmd)) {
         pd->cmd = g_strdup(cmd);
@@ -406,6 +421,9 @@ static void set_config(Mode *sw) {
     if (find_arg_str("-" CALC_ERROR_COLOR, &calc_error_color)) {
         pd->calc_error_color = g_strdup(calc_error_color);
     }
+
+    if (pd->config.live_result_entry)
+        pd->config.no_history = TRUE;
 }
 
 // Get the entries to display.
@@ -680,6 +698,9 @@ static char *calc_get_display_value(const Mode *sw, unsigned int selected_line,
     }
 
     if (selected_line == 0) {
+        if (pd->config.live_result_entry)
+            return g_strdup(pd->last_result);
+
         if (!pd->config.no_history)
             return g_strdup("Add to history");
         else


### PR DESCRIPTION
## Summary

Add an opt-in `live-result-entry` mode that exposes the current calculation
result as a regular list entry instead of only displaying it in rofi's message
widget.

This makes the live result usable in contexts where the message widget of the
calc submode is not displayed, including rofi's combi mode.

## Behavior

When `-live-result-entry` is enabled:

- the current result is shown as the only list entry;
- the entry is updated while typing;
- calculation history is disabled;
- pressing Return prints the result to stdout or runs the configured
  `calc-command`.

The existing behavior remains unchanged unless the option is explicitly
enabled.

## Example

```sh
rofi -show combi \
  -combi-modes "drun,run,calc" \
  -live-result-entry \
  -terse

The option can also be configured with:

calc {
    live-result-entry: true;
}

## Testing

- meson compile -C build
- manually tested live result updates in combi mode
